### PR TITLE
[dragdrop] allow text to be dragged to other apps

### DIFF
--- a/DragAndDrop/DragSourceFragment.cs
+++ b/DragAndDrop/DragSourceFragment.cs
@@ -9,6 +9,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
+using ADragFlags = Android.Views.DragFlags;
 
 using Fragment = AndroidX.Fragment.App.Fragment;
 
@@ -27,8 +28,8 @@ namespace DragAndDrop
             var dragTextView = view.FindViewById<TextView>(Resource.Id.drag_text_view);
             var dragImageView = view.FindViewById<ImageView>(Resource.Id.drag_image_view);
 
-            dragTextView.Tag = new Java.Lang.String("text_view");
-            dragImageView.Tag = new Java.Lang.String("image_view");
+            dragTextView.Tag = new Java.Lang.String("Text");
+            dragImageView.Tag = new Java.Lang.String("Image");
 
             dragTextView.SetOnLongClickListener(this);
             dragImageView.SetOnLongClickListener(this);
@@ -40,17 +41,24 @@ namespace DragAndDrop
         {
             var item = new ClipData.Item(v.Tag.JavaCast<Java.Lang.String>());
             var mimeTypes = new String[1];
+            ClipData data = null;
 
             if (v is ImageView) {
+                // image item only drags WITHIN THE APP 
                 mimeTypes[0] = "image/jpeg";
+                data = new ClipData(v.Tag.JavaCast<Java.Lang.String>().ToString(), mimeTypes, item);
+                // TODO: allow image to drag to other apps
             } else if (v is TextView) {
-                mimeTypes[0] = ClipDescription.MimetypeTextPlain;
+                // use plain text, can drag outside the app
+                data = ClipData.NewPlainText(
+                    new Java.Lang.String(v.Tag.ToString()),
+                    new Java.Lang.String((v as TextView).Text)
+                    );
             }
 
-            var data = new ClipData(v.Tag.JavaCast<Java.Lang.String>().ToString(), mimeTypes, item);
-            
             var dragShadowBuilder = new View.DragShadowBuilder(v);
-            v.StartDragAndDrop(data, dragShadowBuilder, v, 0);
+            // flags required to drag to other apps
+            v.StartDragAndDrop(data, dragShadowBuilder, v, (int)ADragFlags.Global | (int)ADragFlags.GlobalUriRead | (int)ADragFlags.GlobalUriWrite);
             
             return true;
         }

--- a/DragAndDrop/Resources/values/strings.xml
+++ b/DragAndDrop/Resources/values/strings.xml
@@ -4,7 +4,7 @@
   -->
 <resources>
     <string name="app_name">DragAndDrop</string>
-    <string name="plain_text">The perfect balance of productivity and mobility. Surface Duo is a new dual-screen device that fits in your pocket. With two screens connected by a revolutionary 360° hinge, Surface Duo brings together the best of Microsoft and Android to reimagine productivity on the go. Coming Holiday 2020.</string>
-    <string name="drag_image_here">Drag Image here</string>
+    <string name="plain_text">The perfect balance of productivity and mobility. Surface Duo is a new dual-screen device that fits in your pocket. With two screens connected by a revolutionary 360° hinge, Surface Duo brings together the best of Microsoft and Android to reimagine productivity on the go.</string>
+    <string name="drag_image_here">Drag image here</string>
     <string name="drag_text_here">Drag text here</string>
 </resources>


### PR DESCRIPTION
@pureween I realized (belatedly!) that the **DragAndDrop** sample is very limited - it actually doesn't support dragging outside of the app 😬 - this is also true of the kotlin/java source.

I've updated the TEXT dragging to enable dropping into other apps (eg. Office), but this branch doesn't _yet_ allow images to be dragged out. TBD whether to do that right now, or merge this and come back to images... basically need to figure out the complexity of the correct way of doing it.