### PR TITLE
Update Xamarin.Android samples to Jetpack Window Manager beta02

### DIFF
--- a/CompanionPane/CompanionPane.csproj
+++ b/CompanionPane/CompanionPane.csproj
@@ -147,10 +147,10 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/CompanionPane/MainActivity.cs
+++ b/CompanionPane/MainActivity.cs
@@ -16,6 +16,7 @@ using System.Linq;
 /*
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
+01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
 */
 namespace CompanionPane
 {
@@ -55,8 +56,7 @@ namespace CompanionPane
 			dualLandscape.RegisterOnItemSelectedListener(this);
 
 			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
-
+			
 			SetupLayout();
 		}
 
@@ -110,13 +110,13 @@ namespace CompanionPane
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wm.RegisterLayoutChangeCallback(runOnUiThreadExecutor(), this);
+			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wm.UnregisterLayoutChangeCallback(this);
+			wir.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void ShowFragment(Fragment fragment)

--- a/CompanionPane/Slide.cs
+++ b/CompanionPane/Slide.cs
@@ -25,6 +25,6 @@ namespace CompanionPane
 
 		public static IEnumerable<Slide> Slides =>
 			Enumerable.Range(0, 9)
-			.Select(i => new Slide($"Slide {i + 1}", $"Slide Content {i + 1}"));
+			.Select(i => new Slide($"Slide {i + 1}", $"Slide content {i + 1}"));
 	}
 }

--- a/DualView/DualView.csproj
+++ b/DualView/DualView.csproj
@@ -127,10 +127,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/DualView/MainActivity.cs
+++ b/DualView/MainActivity.cs
@@ -15,6 +15,7 @@ using Android.Util;
 /*
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
+01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
 */
 namespace DualView
 {
@@ -115,13 +116,13 @@ namespace DualView
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wm.RegisterLayoutChangeCallback(runOnUiThreadExecutor(), this);
+			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wm.UnregisterLayoutChangeCallback(this);
+			wir.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void UseSingleMode()

--- a/ListDetail/ListDetail.csproj
+++ b/ListDetail/ListDetail.csproj
@@ -107,10 +107,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ListDetail/MainActivity.cs
+++ b/ListDetail/MainActivity.cs
@@ -41,9 +41,7 @@ namespace ListDetail
 			dualPortrait = DualPortrait.NewInstance(items);
 
 			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
-
-
+			
 			SetupLayout();
 		}
 
@@ -97,13 +95,13 @@ namespace ListDetail
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wm.RegisterLayoutChangeCallback(runOnUiThreadExecutor(), this);
+			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wm.UnregisterLayoutChangeCallback(this);
+			wir.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void UseSingleMode()

--- a/TwoPage/MainActivity.cs
+++ b/TwoPage/MainActivity.cs
@@ -30,6 +30,7 @@ using Android.Util;
 		  Use OnStart/Stop instead of OnAttachedToWindow/OnDetached
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
+01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
 */
 namespace TwoPage
 {
@@ -55,8 +56,6 @@ namespace TwoPage
 		View single;
 		View dual;
 
-		//LayoutStateChangeCallback layoutStateChangeCallback = new LayoutStateChangeCallback();
-
 		public bool ShowTwoPages { get; set; } = false;
 
 		protected override void OnCreate(Bundle savedInstanceState)
@@ -66,7 +65,6 @@ namespace TwoPage
 			pagerAdapter = new PagerAdapter(SupportFragmentManager, fragments);
 
 			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
 
 			single = LayoutInflater.Inflate(Resource.Layout.activity_main, null);
 			dual = LayoutInflater.Inflate(Resource.Layout.double_landscape_layout, null);
@@ -121,6 +119,18 @@ namespace TwoPage
 				}
 			}
 			SetupLayout();
+		}
+
+		protected override void OnStart()
+		{
+			base.OnStart();
+			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
+		}
+
+		protected override void OnStop()
+		{
+			base.OnStop();
+			wir.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void UseSingleMode()

--- a/TwoPage/TwoPage.csproj
+++ b/TwoPage/TwoPage.csproj
@@ -99,10 +99,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/WindowManager/MainActivity.cs
+++ b/WindowManager/MainActivity.cs
@@ -26,13 +26,13 @@ using Java.Interop;
 18-Aug-21 Updated to AndroidX.Window-1.0.0-beta01
           Changing IFoldingFeature to interface broke the 'automatic' casting :(
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
+01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
 */
 namespace WindowManagerDemo
 {
     [Activity(Label = "@string/app_name",
     Theme = "@style/AppTheme",
-    MainLauncher = true)]//, // HACK: for some reason the Window Manager doesn't work when configuration changes are being handled 
-    //ConfigurationChanges = Android.Content.PM.ConfigChanges.ScreenSize | Android.Content.PM.ConfigChanges.ScreenLayout | Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.SmallestScreenSize)]
+    MainLauncher = true)]    //ConfigurationChanges = Android.Content.PM.ConfigChanges.ScreenSize | Android.Content.PM.ConfigChanges.ScreenLayout | Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.SmallestScreenSize)]
     public class MainActivity : AppCompatActivity, IConsumer
     {
         const string TAG = "JWM"; // Jetpack Window Manager

--- a/WindowManager/MainActivity.cs
+++ b/WindowManager/MainActivity.cs
@@ -48,9 +48,7 @@ namespace WindowManagerDemo
 
             wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
             wmc = WindowMetricsCalculator.Companion.OrCreate; // HACK: source method is `getOrCreate`, binding generator munges this badly :(
-
-            wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
-            
+           
             // Set our view from the "main" layout resource
             SetContentView(Resource.Layout.activity_main);
             constraintLayout = FindViewById<ConstraintLayout>(Resource.Id.constraint_layout);

--- a/WindowManager/README.md
+++ b/WindowManager/README.md
@@ -2,7 +2,7 @@
 
 Visit the [Window Manager for Xamarin docs](https://docs.microsoft.com/dual-screen/xamarin/) for more information on using Window Manager in your apps.
 
-> NOTE: uses Xamarin.Android.Window.WindowJava-1.0.0.1-beta01, based on Jetpack Window Manager beta01 packages
+> NOTE: uses Xamarin.Android.Window.WindowJava-1.0.0.1-beta02, based on Jetpack Window Manager beta02 packages
 
 ![Window Manager example spanned across two screens](../Screenshots/xamarin-window-manager.png)
 

--- a/WindowManager/Resources/values/strings.xml
+++ b/WindowManager/Resources/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">Xamarin WindowInfoRepository beta01</string>
+  <string name="app_name">Xamarin WindowInfoRepository beta02</string>
   <string name="window_metrics">window metrics</string>
   <string name="layout_change_text">layout change text</string>
   <string name="configuration_changed">Using one logic/physical display - unspanned</string>

--- a/WindowManager/WindowManager.csproj
+++ b/WindowManager/WindowManager.csproj
@@ -103,10 +103,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta01</Version>
+      <Version>1.0.0.1-beta02</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR was tested with bindings generated by the build system for https://github.com/xamarin/AndroidX/pull/369

~**DO NOT MERGE** until the [Xamarin.AndroidX.Window/1.0.0.1-beta02](https://www.nuget.org/packages/Xamarin.AndroidX.Window/1.0.0.1-beta02) NuGet is published.~