### PR TITLE
[all] update Jetpack Window Manager (beta04)

### DIFF
--- a/CompanionPane/CompanionPane.csproj
+++ b/CompanionPane/CompanionPane.csproj
@@ -147,10 +147,10 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/CompanionPane/CompanionPane.csproj
+++ b/CompanionPane/CompanionPane.csproj
@@ -17,7 +17,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
@@ -146,11 +146,8 @@
     <PackageReference Include="Xamarin.AndroidX.RecyclerView">
       <Version>1.1.0</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.3-beta03</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.3-beta03</Version>
+      <Version>1.0.0.5-beta04</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/CompanionPane/MainActivity.cs
+++ b/CompanionPane/MainActivity.cs
@@ -17,7 +17,9 @@ using System.Linq;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
-02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03 (note: beta03 was never deployed to NuGet.org)
+02-Dec-21 Updated to AndroidX.Window-1.0.0-beta04
+          Renamed WindowInfoRepository to WindowInfoTracker, added Activity context parameter
 */
 namespace CompanionPane
 {
@@ -31,7 +33,7 @@ namespace CompanionPane
 	public class MainActivity : AppCompatActivity, BaseFragment.IOnItemSelectedListener, IConsumer
 	{
 		const string TAG = "JWM"; // Jetpack Window Manager
-		WindowInfoRepositoryCallbackAdapter wir;
+		WindowInfoTrackerCallbackAdapter wit;
 		FoldingFeatureOrientation hingeOrientation = FoldingFeatureOrientation.Vertical;
 		bool isDuo, isDualMode;
 
@@ -56,7 +58,7 @@ namespace CompanionPane
 			dualLandscape = DualLandscape.NewInstance(slides);
 			dualLandscape.RegisterOnItemSelectedListener(this);
 
-			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
+			wit = new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.Companion.GetOrCreate(this));
 			
 			SetupLayout();
 		}
@@ -111,13 +113,14 @@ namespace CompanionPane
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
+			wit.AddWindowLayoutInfoListener(this, runOnUiThreadExecutor(), this);
+			// first `this` is the Activity context, second `this` is the IConsumer implementation
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wir.RemoveWindowLayoutInfoListener(this);
+			wit.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void ShowFragment(Fragment fragment)

--- a/CompanionPane/MainActivity.cs
+++ b/CompanionPane/MainActivity.cs
@@ -17,6 +17,7 @@ using System.Linq;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
 */
 namespace CompanionPane
 {

--- a/CompanionPane/Properties/AndroidManifest.xml
+++ b/CompanionPane/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.companionpane">
-	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/DualView/DualView.csproj
+++ b/DualView/DualView.csproj
@@ -17,7 +17,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
@@ -126,11 +126,8 @@
     <PackageReference Include="Xamarin.AndroidX.ConstraintLayout">
       <Version>2.0.4.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.3-beta03</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.3-beta03</Version>
+      <Version>1.0.0.5-beta04</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/DualView/DualView.csproj
+++ b/DualView/DualView.csproj
@@ -127,10 +127,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/DualView/MainActivity.cs
+++ b/DualView/MainActivity.cs
@@ -16,7 +16,9 @@ using Android.Util;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
-02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03 (note: beta03 was never deployed to NuGet.org)
+02-Dec-21 Updated to AndroidX.Window-1.0.0-beta04
+          Renamed WindowInfoRepository to WindowInfoTracker, added Activity context parameter
 */
 namespace DualView
 {
@@ -31,7 +33,7 @@ namespace DualView
 	public class MainActivity : AppCompatActivity, BaseFragment.IOnItemSelectedListener, IConsumer
 	{
 		const string TAG = "JWM"; // Jetpack Window Manager
-		WindowInfoRepositoryCallbackAdapter wir;
+		WindowInfoTrackerCallbackAdapter wit;
 		FoldingFeatureOrientation hingeOrientation = FoldingFeatureOrientation.Vertical;
 		bool isDuo, isDualMode;
 
@@ -60,9 +62,7 @@ namespace DualView
 			dualLandscape.RegisterOnItemSelectedListener(this);
 			fragmentMap[GetSimpleName<DualLandscape>()] = dualLandscape;
 
-			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
-
+			wit = new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.Companion.GetOrCreate(this));
 
 			SetupLayout();
 		}
@@ -117,13 +117,14 @@ namespace DualView
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
+			wit.AddWindowLayoutInfoListener(this, runOnUiThreadExecutor(), this);
+		 	// first `this` is the Activity context, second `this` is the IConsumer implementation
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wir.RemoveWindowLayoutInfoListener(this);
+			wit.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void UseSingleMode()

--- a/DualView/MainActivity.cs
+++ b/DualView/MainActivity.cs
@@ -16,6 +16,7 @@ using Android.Util;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
 */
 namespace DualView
 {

--- a/DualView/Properties/AndroidManifest.xml
+++ b/DualView/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.dualview">
-	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/ListDetail/ListDetail.csproj
+++ b/ListDetail/ListDetail.csproj
@@ -17,7 +17,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
@@ -106,11 +106,8 @@
     <PackageReference Include="Xamarin.AndroidX.ConstraintLayout">
       <Version>2.0.4.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.3-beta03</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.3-beta03</Version>
+      <Version>1.0.0.5-beta04</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ListDetail/ListDetail.csproj
+++ b/ListDetail/ListDetail.csproj
@@ -107,10 +107,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ListDetail/MainActivity.cs
+++ b/ListDetail/MainActivity.cs
@@ -16,7 +16,9 @@ using Android.Util;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
-02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03 (note: beta03 was never deployed to NuGet.org)
+02-Dec-21 Updated to AndroidX.Window-1.0.0-beta04
+          Renamed WindowInfoRepository to WindowInfoTracker, added Activity context parameter
 */
 namespace ListDetail
 {
@@ -30,7 +32,7 @@ namespace ListDetail
 	public class MainActivity : AppCompatActivity, IConsumer
 	{
 		const string TAG = "JWM"; // Jetpack Window Manager
-		WindowInfoRepositoryCallbackAdapter wir;
+		WindowInfoTrackerCallbackAdapter wit;
 		FoldingFeatureOrientation hingeOrientation = FoldingFeatureOrientation.Vertical;
 		bool isDuo, isDualMode;
 
@@ -45,7 +47,7 @@ namespace ListDetail
 			singlePortrait = SinglePortrait.NewInstance(items);
 			dualPortrait = DualPortrait.NewInstance(items);
 
-			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
+			wit = new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.Companion.GetOrCreate(this));
 			
 			SetupLayout();
 		}
@@ -100,13 +102,14 @@ namespace ListDetail
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
+			wit.AddWindowLayoutInfoListener(this, runOnUiThreadExecutor(), this);
+			 // first `this` is the Activity context, second `this` is the IConsumer implementation
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wir.RemoveWindowLayoutInfoListener(this);
+			wit.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void UseSingleMode()

--- a/ListDetail/MainActivity.cs
+++ b/ListDetail/MainActivity.cs
@@ -12,7 +12,12 @@ using AndroidX.Core.Util;
 using Java.Util.Concurrent;
 using Java.Lang;
 using Android.Util;
-
+/*
+23-Aug-21 Update to androidx.window-1.0.0-beta01
+          HACK: need to JavaCast IDisplayFeature to IFoldingFeature
+01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
+*/
 namespace ListDetail
 {
 	[Android.App.Activity(

--- a/ListDetail/Properties/AndroidManifest.xml
+++ b/ListDetail/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.listdetail">
-	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/TwoPage/MainActivity.cs
+++ b/TwoPage/MainActivity.cs
@@ -31,6 +31,7 @@ using Android.Util;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
 */
 namespace TwoPage
 {

--- a/TwoPage/MainActivity.cs
+++ b/TwoPage/MainActivity.cs
@@ -31,7 +31,9 @@ using Android.Util;
 23-Aug-21 Update to androidx.window-1.0.0-beta01
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
-02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03 (note: beta03 was never deployed to NuGet.org)
+02-Dec-21 Updated to AndroidX.Window-1.0.0-beta04
+          Renamed WindowInfoRepository to WindowInfoTracker, added Activity context parameter
 */
 namespace TwoPage
 {
@@ -45,7 +47,7 @@ namespace TwoPage
 	public class MainActivity : AppCompatActivity, ViewPager.IOnPageChangeListener, IConsumer
 	{
 		const string TAG = "JWM"; // Jetpack Window Manager
-		WindowInfoRepositoryCallbackAdapter wir;
+		WindowInfoTrackerCallbackAdapter wit;
 		FoldingFeatureOrientation hingeOrientation = FoldingFeatureOrientation.Vertical;
 		bool isDuo, isDualMode; 
 		
@@ -65,7 +67,7 @@ namespace TwoPage
 			var fragments = TestFragment.Fragments;
 			pagerAdapter = new PagerAdapter(SupportFragmentManager, fragments);
 
-			wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
+			wit = new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.Companion.GetOrCreate(this));
 
 			single = LayoutInflater.Inflate(Resource.Layout.activity_main, null);
 			dual = LayoutInflater.Inflate(Resource.Layout.double_landscape_layout, null);
@@ -125,13 +127,14 @@ namespace TwoPage
 		protected override void OnStart()
 		{
 			base.OnStart();
-			wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this);
+			wit.AddWindowLayoutInfoListener(this, runOnUiThreadExecutor(), this);
+			// first `this` is the Activity context, second `this` is the IConsumer implementation
 		}
 
 		protected override void OnStop()
 		{
 			base.OnStop();
-			wir.RemoveWindowLayoutInfoListener(this);
+			wit.RemoveWindowLayoutInfoListener(this);
 		}
 
 		void UseSingleMode()

--- a/TwoPage/Properties/AndroidManifest.xml
+++ b/TwoPage/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.twopage">
-	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/TwoPage/TwoPage.csproj
+++ b/TwoPage/TwoPage.csproj
@@ -99,10 +99,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/TwoPage/TwoPage.csproj
+++ b/TwoPage/TwoPage.csproj
@@ -17,7 +17,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
@@ -98,11 +98,8 @@
     <PackageReference Include="Xamarin.AndroidX.ConstraintLayout">
       <Version>2.0.4.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.3-beta03</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.3-beta03</Version>
+      <Version>1.0.0.5-beta04</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/WindowManager/MainActivity.cs
+++ b/WindowManager/MainActivity.cs
@@ -27,7 +27,9 @@ using Java.Interop;
           Changing IFoldingFeature to interface broke the 'automatic' casting :(
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
-02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03 (note: beta03 was never deployed to NuGet.org)
+02-Dec-21 Updated to AndroidX.Window-1.0.0-beta04
+          Renamed WindowInfoRepository to WindowInfoTracker, added Activity context parameter
 */
 namespace WindowManagerDemo
 {
@@ -37,7 +39,7 @@ namespace WindowManagerDemo
     public class MainActivity : AppCompatActivity, IConsumer
     {
         const string TAG = "JWM"; // Jetpack Window Manager
-        WindowInfoRepositoryCallbackAdapter wir;
+        WindowInfoTrackerCallbackAdapter wit;
         IWindowMetricsCalculator wmc;
 
         ConstraintLayout constraintLayout;
@@ -47,7 +49,7 @@ namespace WindowManagerDemo
         {
             base.OnCreate(savedInstanceState);
 
-            wir = new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.Companion.GetOrCreate(this));
+            wit = new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.Companion.GetOrCreate(this));
             wmc = WindowMetricsCalculator.Companion.OrCreate; // HACK: source method is `getOrCreate`, binding generator munges this badly :(
            
             // Set our view from the "main" layout resource
@@ -61,13 +63,14 @@ namespace WindowManagerDemo
         protected override void OnStart()
         {
             base.OnStart();
-            wir.AddWindowLayoutInfoListener(runOnUiThreadExecutor(), this); // `this` is the IConsumer implementation
+            wit.AddWindowLayoutInfoListener(this, runOnUiThreadExecutor(), this); 
+            // first `this` is the Activity context, second `this` is the IConsumer implementation
         }
     
         protected override void OnStop()
         {
             base.OnStop();
-            wir.RemoveWindowLayoutInfoListener(this);
+            wit.RemoveWindowLayoutInfoListener(this);
         }
 
         void printLayoutStateChange(WindowLayoutInfo newLayoutInfo)

--- a/WindowManager/MainActivity.cs
+++ b/WindowManager/MainActivity.cs
@@ -27,6 +27,7 @@ using Java.Interop;
           Changing IFoldingFeature to interface broke the 'automatic' casting :(
           HACK: need to JavaCast IDisplayFeature to IFoldingFeature
 01-Sep-21 Updated to AndroidX.Window-1.0.0-beta02
+02-Nov-21 Updated to AndroidX.Window-1.0.0-beta03
 */
 namespace WindowManagerDemo
 {

--- a/WindowManager/Properties/AndroidManifest.xml
+++ b/WindowManager/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.windowmanager" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="29" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/WindowManager/README.md
+++ b/WindowManager/README.md
@@ -2,7 +2,7 @@
 
 Visit the [Window Manager for Xamarin docs](https://docs.microsoft.com/dual-screen/xamarin/) for more information on using Window Manager in your apps.
 
-> NOTE: uses Xamarin.Android.Window.WindowJava-1.0.0.1-beta02, based on Jetpack Window Manager beta02 packages
+> NOTE: uses Xamarin.Android.Window.WindowJava-1.0.0.3-beta03, based on Jetpack Window Manager beta03 packages
 
 ![Window Manager example spanned across two screens](../Screenshots/xamarin-window-manager.png)
 

--- a/WindowManager/README.md
+++ b/WindowManager/README.md
@@ -2,7 +2,7 @@
 
 Visit the [Window Manager for Xamarin docs](https://docs.microsoft.com/dual-screen/xamarin/) for more information on using Window Manager in your apps.
 
-> NOTE: uses Xamarin.Android.Window.WindowJava-1.0.0.3-beta03, based on Jetpack Window Manager beta03 packages
+> NOTE: uses Xamarin.Android.Window.WindowJava-1.0.0.5-beta04, based on Jetpack Window Manager beta04 packages
 
 ![Window Manager example spanned across two screens](../Screenshots/xamarin-window-manager.png)
 

--- a/WindowManager/Resources/values/strings.xml
+++ b/WindowManager/Resources/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">Xamarin WindowInfoRepository beta03</string>
+  <string name="app_name">Xamarin WindowInfoRepository beta04</string>
   <string name="window_metrics">window metrics</string>
   <string name="layout_change_text">layout change text</string>
   <string name="configuration_changed">Using one logic/physical display - unspanned</string>

--- a/WindowManager/Resources/values/strings.xml
+++ b/WindowManager/Resources/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">Xamarin WindowInfoRepository beta02</string>
+  <string name="app_name">Xamarin WindowInfoRepository beta03</string>
   <string name="window_metrics">window metrics</string>
   <string name="layout_change_text">layout change text</string>
   <string name="configuration_changed">Using one logic/physical display - unspanned</string>

--- a/WindowManager/WindowManager.csproj
+++ b/WindowManager/WindowManager.csproj
@@ -103,10 +103,10 @@
       <Version>2.0.4.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.1-beta02</Version>
+      <Version>1.0.0.3-beta03</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0" />
   </ItemGroup>

--- a/WindowManager/WindowManager.csproj
+++ b/WindowManager/WindowManager.csproj
@@ -19,7 +19,7 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
@@ -102,11 +102,8 @@
     <PackageReference Include="Xamarin.AndroidX.ConstraintLayout">
       <Version>2.0.4.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Window">
-      <Version>1.0.0.3-beta03</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Window.WindowJava">
-      <Version>1.0.0.3-beta03</Version>
+      <Version>1.0.0.5-beta04</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated Xamarin.Android projects to test Jetpack Window Manager **beta04** package.

https://www.nuget.org/packages/Xamarin.AndroidX.Window/1.0.0.5-beta04

**beta03** binding was built and tested BUT not merged or deployed as beta04 came while it was still 'in progress'

~Updated Xamarin.Android projects to test Jetpack Window Manager beta03 package.~

~This branch updates requires test NuGets from the CI on https://github.com/xamarin/AndroidX/pull/418~

Progress towards #20 