### PR TITLE
Remove Xamarin product metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ languages:
 - csharp
 products:
 - surface-duo
-- xamarin
 description: "Samples showing how to use the Surface Duo SDK to achieve dual-screen user interface patterns using Xamarin and Xamarin.Forms."
 urlFragment: all
 ---


### PR DESCRIPTION
Remove the Xamarin product metadata to stop this sample appearing in the samples browser under Xamarin, which has now reached end of support.